### PR TITLE
Feat: let a drag leaving a blade hand files to the system

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,6 +270,27 @@ from the application opened for the files. Multi-file edits use one editor
 launch; a default-open batch may map several clients, but FileBlade stays out
 of the focus race and Hyprland leaves the last activated client active.
 
+A file drag can also run as a Wayland drag. A compositor drag owns the pointer
+and the keyboard for as long as it lasts, so the drop wheel, its keys and the
+drag scroll cannot run inside one, and the choice has to be made before the
+gesture starts rather than when it leaves the blade. With `dragOut` set to
+`system`, `BrowserRow` starts the gesture as `Drag.Automatic`, the compositor
+offers `text/uri-list`, and any client that accepts files receives the
+selection. Dragging a row with the right button keeps that gesture internal
+and opens the drop wheel where the drag is released outside a blade, without
+waiting for the wheel key; the wheel then owns the pointer and the keyboard as
+usual, because the drag is over. Shift or control at the press also keeps the
+drag internal, so the absolute and relative path pastes work as they always
+have. `dragOut`
+defaults to `paste` and every drag stays internal, which is the behavior
+FileBlade has always had.
+
+Row drop targets accept `text/uri-list` beside the internal drag key, because a
+system offer carries mime types rather than the key. That is what lets a
+promoted drag still land on a folder row, and it also accepts files dragged in
+from other applications. `PathText.droppedPath` resolves an offered url whether
+the compositor percent-encodes it or not, so a name with a space survives.
+
 ![Keybind flow](assets/docs/keybind-flow.svg)
 
 FileBlade does not edit your Hyprland config. The blade-aware binds in the
@@ -391,6 +412,7 @@ pickerResult:   picker dialog flow, answer from the pick blade
 select:         single-path form of selectEntries, which fileblade select uses
 setWelcomeState: Welcome tab flow; VM section 29 resets the first-launch state
 setModeBadge:   Files settings row for the Neovim mode badge (header, footer, hidden); VM section 17 flips it and reads status.modeBadge
+setDragOut:     Files settings row for what a drag leaving a blade does (paste, system); VM section 17 flips it and reads status.dragOut
 welcomeInstall: Welcome tab flow; starts the detached four-extension installer
 welcomeDismiss: Welcome tab flow; closes the tab and records the choice
 resetBladeLayout: applies the default blade layout, which seeds the Welcome tab while it is pending
@@ -484,6 +506,7 @@ folderColorScope:           icon       what a folder color paints: icon, name, o
 trashRetentionDays:         7          days before Trash entries are pruned; 0 keeps them forever
 gitStatusPollIntervalMs:     5000       Git fallback base in ms; 6x while inotify is healthy, 0 disables it
 dropModifier:               space      drop-wheel hold key: space, alt, ctrl, shift, or meta
+dragOut:                    paste      what a drag leaving a blade does: paste the path, or hand it to the system
 monitorMode:                active     invocation monitor; all mirrors, locked uses the saved monitorLock
 animateBlades:              true       slide blades open and closed
 checkUpdates:               true       the six-hourly ref lookup described under Checkout update checks

--- a/Service.qml
+++ b/Service.qml
@@ -165,6 +165,7 @@ Item {
   property alias autoHideSearch: stateController.autoHideSearch
   property alias showSystemVolumes: stateController.showSystemVolumes
   property alias modeBadge: stateController.modeBadge
+  property alias dragOut: stateController.dragOut
   property string editorMode: "NORMAL"
   readonly property color editorModeColor: editorMode === "VISUAL" ? themedFolderColor("magenta", "#c678dd") : (editorMode === "INSERT" ? themedFolderColor("green", "#98c379") : themedFolderColor("blue", "#61afef"))
   property alias folderColorScope: stateController.folderColorScope
@@ -506,6 +507,7 @@ Item {
     id: dropWheelController
     service: service
     modifierName: String(service.pluginConfig().dropModifier || "space").toLowerCase()
+    systemDragOut: service.dragOut === "system"
   }
 
   LaunchController {
@@ -612,6 +614,7 @@ Item {
   function numberValue(value, fallback, minimum, maximum) { return configController.numberValue(value, fallback, minimum, maximum) }
   function normalizePlacement(value) { return configController.normalizePlacement(value) }
   function normalizeModeBadge(value) { return configController.normalizeModeBadge(value) }
+  function normalizeDragOut(value) { return configController.normalizeDragOut(value) }
   function normalizeMonitorMode(value) { return configController.normalizeMonitorMode(value) }
   function normalizePriorityProperty(value) { return configController.normalizePriorityProperty(value) }
   function priorityPropertyLabel(value) { return configController.priorityPropertyLabel(value, false) }
@@ -999,6 +1002,12 @@ Item {
     modeBadge = normalizeModeBadge(value)
     scheduleStateSave()
     return modeBadge
+  }
+
+  function setDragOut(value) {
+    dragOut = normalizeDragOut(value)
+    scheduleStateSave()
+    return dragOut
   }
 
   function makeRow(entry, depth) { return selectionController.makeRow(entry, depth) }

--- a/controllers/ConfigController.qml
+++ b/controllers/ConfigController.qml
@@ -61,6 +61,13 @@ Item {
     return ["header", "footer", "hidden"].indexOf(badge) >= 0 ? badge : "header"
   }
 
+  function normalizeDragOut(value) {
+    var mode = String(value || "").toLowerCase()
+    if (mode === "wayland" || mode === "handoff") mode = "system"
+    if (mode === "path" || mode === "type") mode = "paste"
+    return ["paste", "system"].indexOf(mode) >= 0 ? mode : "paste"
+  }
+
   function normalizeMonitorMode(value) {
     return MonitorMode.normalize(value)
   }

--- a/controllers/DropWheelController.qml
+++ b/controllers/DropWheelController.qml
@@ -25,6 +25,7 @@ Item {
   readonly property int modifierKey: modifierSpec.key
   readonly property string modifierLabel: modifierSpec.label
 
+  property bool systemDragOut: false
   property bool dragActive: false
   property bool dragDocked: true
   property bool dragOutside: false
@@ -246,6 +247,12 @@ Item {
     wheelOpen = true
     requestContext()
     openedAt(wheelScreen, wheelX, wheelY)
+  }
+
+  function openAfterDrag() {
+    if (wheelOpen || dragPaths.length === 0) return false
+    openWheel(dragScreen, pointerX, pointerY, false)
+    return true
   }
 
   function resetHighlight() {

--- a/controllers/FileTreeIpc.qml
+++ b/controllers/FileTreeIpc.qml
@@ -138,6 +138,7 @@ QtObject {
       drivesMode: service.drivesMode,
       drivesCount: service.drivesController.volumeCount,
       modeBadge: service.modeBadge,
+      dragOut: service.dragOut,
       editorMode: service.editorMode,
       trashCount: service.trashCount,
       trashSelectedId: service.trashSelectedId,
@@ -684,6 +685,10 @@ QtObject {
 
   function setModeBadge(placement: string): string {
     return service.setModeBadge(placement)
+  }
+
+  function setDragOut(mode: string): string {
+    return service.setDragOut(mode)
   }
 
   function focusBlade(edge: string): string {

--- a/controllers/OperationController.qml
+++ b/controllers/OperationController.qml
@@ -69,7 +69,7 @@ Item {
     var sources = Array.isArray(paths) ? paths : service.selectedPaths
     var uris = []
     for (var i = 0; i < sources.length; i++) uris.push(service.fileUrl(sources[i]))
-    return uris.join("\n")
+    return uris.length === 0 ? "" : uris.join("\r\n") + "\r\n"
   }
 
   function copySelection(cut, paths) {

--- a/controllers/StateController.qml
+++ b/controllers/StateController.qml
@@ -53,6 +53,7 @@ Item {
   property alias autoHideSearch: persisted.autoHideSearch
   property alias showSystemVolumes: persisted.showSystemVolumes
   property alias modeBadge: persisted.modeBadge
+  property alias dragOut: persisted.dragOut
   property alias folderColorScope: persisted.folderColorScope
   property alias treeSort: persisted.treeSort
   property alias treeFilter: persisted.treeFilter
@@ -92,6 +93,7 @@ Item {
     property bool autoHideSearch: false
     property bool showSystemVolumes: false
     property string modeBadge: "header"
+    property string dragOut: "paste"
     property string folderColorScope: "icon"
     property var treeSort: []
     property var treeFilter: ({})
@@ -566,6 +568,7 @@ Item {
       autoHideSearch: service.boolValue(config.autoHideSearch, false),
       showSystemVolumes: service.boolValue(config.showSystemVolumes, false),
       modeBadge: service.normalizeModeBadge(config.modeBadge),
+      dragOut: service.normalizeDragOut(config.dragOut),
       folderColorScope: normalizedFolderColorScope(config.folderColorScope),
       trashRetentionDays: 0
     }
@@ -590,6 +593,7 @@ Item {
     autoHideSearch = base.autoHideSearch
     showSystemVolumes = base.showSystemVolumes
     modeBadge = base.modeBadge
+    dragOut = base.dragOut
     folderColorScope = base.folderColorScope
     treeSort = TreeOrder.normalizeSorts([])
     treeFilter = TreeOrder.normalizeFilter({})
@@ -649,6 +653,7 @@ Item {
     autoHideSearch = service.boolValue(state.autoHideSearch, base.autoHideSearch)
     showSystemVolumes = service.boolValue(state.showSystemVolumes, base.showSystemVolumes)
     modeBadge = state.modeBadge === undefined ? base.modeBadge : service.normalizeModeBadge(state.modeBadge)
+    dragOut = state.dragOut === undefined ? base.dragOut : service.normalizeDragOut(state.dragOut)
     folderColorScope = state.folderColorScope === undefined ? base.folderColorScope : normalizedFolderColorScope(state.folderColorScope)
     treeSort = TreeOrder.normalizeSorts(state.treeSort)
     treeFilter = TreeOrder.normalizeFilter(state.treeFilter)
@@ -705,6 +710,7 @@ Item {
       autoHideSearch: autoHideSearch,
       showSystemVolumes: showSystemVolumes,
       modeBadge: modeBadge,
+      dragOut: dragOut,
       folderColorScope: folderColorScope,
       treeSort: treeSort,
       treeFilter: treeFilter,

--- a/docs/agent-written/README.md
+++ b/docs/agent-written/README.md
@@ -13,6 +13,9 @@ is maintained separately.
   and how data moves through it
 - [Keybindings](keybindings.md): user configuration for pane navigation,
   folding, search and help
+- [Dragging files](dragging-files.md): which mouse gesture keeps a drag inside
+  FileBlade, which one hands the files to another application, and the setting
+  that chooses between them
 - [Git status](git-status.md): status markers and repository summary preferences
 - [Extensions](../../EXTENSIONS.md): the public contract for blade modules and
   other FileBlade extension points

--- a/docs/agent-written/dragging-files.md
+++ b/docs/agent-written/dragging-files.md
@@ -1,0 +1,42 @@
+# Dragging files
+
+This file was written by an agent.
+
+FileBlade carries two kinds of file drag. One stays inside FileBlade and ends in
+the drop wheel or a folder row. The other belongs to the compositor and hands the
+files to whatever application you drop them on. A Wayland drag owns the pointer
+and the keyboard while it lasts, so a single gesture cannot be both, and the
+button you press decides which one you get.
+
+## The setting
+
+**Files settings → Drag out**, or `dragOut` in the plugin config.
+
+| Value | Dragging a row with the left button |
+|---|---|
+| `paste` (default) | stays inside FileBlade, exactly as it always has |
+| `system` | hands the files to the application you drop on |
+
+## Gestures
+
+| Gesture | Result |
+|---|---|
+| Left button, `dragOut: system` | the application you drop on receives the files |
+| Left button, `dragOut: paste` | the drag stays inside FileBlade |
+| Right button | stays inside FileBlade and opens the drop wheel where you release it outside a blade |
+| Shift + left button | stays inside FileBlade and pastes the absolute path |
+| Ctrl + left button | stays inside FileBlade and pastes the relative path |
+| The drop-wheel key during an internal drag | opens the wheel, as before |
+
+Dropping on a folder row inside a blade moves or copies the files whichever
+gesture started the drag, and folder rows also accept files dragged in from
+other applications.
+
+## What a system drag cannot do
+
+The compositor owns the pointer and the keyboard for the whole drag, so during a
+left-button drag under `dragOut: system` the drop wheel does not open, its keys
+and scrolling do not reach FileBlade, and the file list does not scroll itself
+when you reach its edge. Use the right button when you want the wheel, and shift
+or control when you want a path pasted. Under the default setting none of this
+applies, because every drag stays inside FileBlade.

--- a/lib/PathText.js
+++ b/lib/PathText.js
@@ -47,6 +47,20 @@ function fileUrl(value) {
   catch (_) { return "" }
 }
 
+function droppedPath(value) {
+  var text = String(value === undefined || value === null ? "" : value)
+  if (!/^file:\/\//i.test(text)) return ""
+  var body = text.slice(7)
+  if (/^localhost\//i.test(body)) body = body.slice(9)
+  if (body.charAt(0) !== "/") return ""
+  if (/%[0-9a-f]{2}/i.test(body)) {
+    try { body = decodeURIComponent(body) }
+    catch (_) { return "" }
+  }
+  if (body.indexOf("\0") >= 0) return ""
+  return normalizeParts(body.split("/"))
+}
+
 function fromFileUrl(value) {
   var uri = fileUrl(value)
   if (!uri) return String(value || "")

--- a/modules/files/FilesSettings.qml
+++ b/modules/files/FilesSettings.qml
@@ -74,6 +74,15 @@ Column {
     onChosen: function(key) { root.controller.setModeBadge(key) }
   }
 
+  PluginUi.ChoiceRow {
+    width: parent.width
+    glyph: "\uf0c1"
+    label: "Drag out"
+    options: [{ key: "paste", label: "Paste path" }, { key: "system", label: "System drag" }]
+    value: root.controller.dragOut
+    onChosen: function(key) { root.controller.setDragOut(key) }
+  }
+
   PluginUi.SettingsGroup { title: "Git" }
 
   PluginUi.ToggleRow {

--- a/panes/BrowserDropTarget.qml
+++ b/panes/BrowserDropTarget.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import "../lib/PathText.js" as PathText
 
 DropArea {
   id: target
@@ -6,14 +7,26 @@ DropArea {
   required property var controller
   required property var rowItem
 
-  keys: ["fileblade-entry"]
+  keys: ["fileblade-entry", "text/uri-list"]
   enabled: rowItem.dropAllowed
+
+  function droppedPaths(drop) {
+    if (!drop.hasUrls) return rowItem.draggedPaths.slice()
+    var paths = []
+    for (var i = 0; i < drop.urls.length; i++) {
+      var path = PathText.droppedPath(drop.urls[i])
+      if (path) paths.push(path)
+    }
+    return paths
+  }
 
   onEntered: if (rowItem.treeMode && !rowItem.expanded) hoverExpand.restart()
   onExited: hoverExpand.stop()
   onDropped: function(drop) {
     hoverExpand.stop()
-    controller.moveSelectionTo(rowItem.path, drop.proposedAction === Qt.CopyAction, rowItem.draggedPaths.slice())
+    var paths = target.droppedPaths(drop)
+    if (paths.length === 0) return
+    controller.moveSelectionTo(rowItem.path, drop.proposedAction === Qt.CopyAction, paths)
     drop.acceptProposedAction()
   }
 

--- a/panes/BrowserRow.qml
+++ b/panes/BrowserRow.qml
@@ -490,6 +490,9 @@ Rectangle {
 
   HoverHandler { id: hoverTracker }
 
+  property bool systemDragActive: false
+  property bool wheelGesture: false
+
   Drag.active: false
   Drag.source: row
   Drag.keys: ["fileblade-entry"]
@@ -524,6 +527,14 @@ Rectangle {
     updateDragScroll()
   }
 
+  function systemDragWanted(buttons, modifiers) {
+    var held = Number(buttons) || 0
+    var keys = Number(modifiers) || 0
+    if (held & Qt.RightButton) return false
+    if (keys & (Qt.ShiftModifier | Qt.ControlModifier)) return false
+    return controller.dropWheel.systemDragOut
+  }
+
   function updateDragScroll() {
     if (!ownerView || ownerView.height <= 0) {
       dragScrollStep = 0
@@ -544,23 +555,31 @@ Rectangle {
   DragHandler {
     id: dragHandler
     target: null
-    acceptedButtons: Qt.LeftButton
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
     enabled: !row.customInteraction && row.selectable && !row.gitDeleted
     cursorShape: active ? Qt.ClosedHandCursor : Qt.PointingHandCursor
     onActiveChanged: {
       if (active) {
         row.dragCanceled = false
         if (!controller.isSelected(row.path)) row.choose(Qt.NoModifier)
+        row.wheelGesture = (Number(dragHandler.centroid.pressedButtons) & Qt.RightButton) !== 0
+        row.systemDragActive = row.systemDragWanted(dragHandler.centroid.pressedButtons, dragHandler.centroid.modifiers)
+        row.Drag.dragType = row.systemDragActive ? Drag.Automatic : Drag.Internal
         row.beginDropDrag()
         row.Drag.active = true
         return
       }
       row.dragScrollStep = 0
+      row.systemDragActive = false
+      var openWheelNow = row.wheelGesture && !row.dragCanceled && controller.dropWheel.dragOutside
+      row.wheelGesture = false
       if (row.Drag.active) {
         if (row.dragCanceled) row.Drag.cancel()
         else row.Drag.drop()
       }
+      if (openWheelNow) controller.dropWheel.dragConsumed = true
       controller.dropWheel.endDrag(undefined, undefined, undefined)
+      if (openWheelNow) controller.dropWheel.openAfterDrag()
     }
     onCanceled: row.dragCanceled = true
     onCentroidChanged: if (active) row.updateDropDrag()

--- a/tests/EXPECTATIONS.md
+++ b/tests/EXPECTATIONS.md
@@ -478,6 +478,11 @@ Dialog keyboard regressions: `tests/vm/trash-dialog-focus.sh`.
      text in every blade grows or shrinks by that amount while the blade widths
      stay where I put them, a value outside the range settles on the nearest
      end, and the choice survives a restart.
+147c. **E-17-14** If I set Drag out to System drag in the Files settings,
+     dragging rows hands the files to the window I drop on, so an application
+     that takes files receives them instead of their typed paths, and the drop
+     wheel stays out of that drag unless I drag with my right button;
+     Paste path restores the old behavior, and the choice survives a restart.
 
 ## 18. Persistence
 
@@ -779,6 +784,18 @@ missing, the same goes for "This nvim", and picking one anyway is refused
 with the reason; New terminal and Review with hunk in a new window still
 work. tmux gives no way to tell such windows apart, so it always counts as
 shared there.
+
+**E-26-13** If I set dragging out to hand files to the system, dragging rows
+gives them to the application I drop on, so a browser upload field receives the
+files themselves. That drag belongs to the compositor, so the drop wheel, its
+keys and the drag scroll do not take part in it; dragging the row with my right
+button keeps that gesture inside FileBlade instead and opens the wheel where I
+release it outside the blade, without pressing the wheel key, and holding shift
+or control as I press keeps it inside too, so the path pastes still work. With
+the default setting every drag stays inside FileBlade, as it always has.
+
+**E-26-14** I can drop files dragged from another application onto a folder row
+in a blade, and a name containing a space arrives intact.
 
 ## 27. Updates and recovery
 

--- a/tests/qml/tst_path_text.qml
+++ b/tests/qml/tst_path_text.qml
@@ -5,6 +5,21 @@ import "../../lib/PathText.js" as PathText
 TestCase {
   name: "PathIdentity"
 
+  function test_dropped_urls_survive_spaces_in_either_form() {
+    compare(PathText.droppedPath("file:///home/user/folder%20test"), "/home/user/folder test")
+    compare(PathText.droppedPath("file:///home/user/folder test"), "/home/user/folder test")
+    compare(PathText.droppedPath("file://localhost/home/user/folder%20test"), "/home/user/folder test")
+    compare(PathText.droppedPath("file:///home/user/a%23b/c%20d.png"), "/home/user/a#b/c d.png")
+  }
+
+  function test_dropped_urls_reject_what_is_not_a_local_file() {
+    compare(PathText.droppedPath(""), "")
+    compare(PathText.droppedPath(undefined), "")
+    compare(PathText.droppedPath("https://example.com/thing.png"), "")
+    compare(PathText.droppedPath("file://server/share/thing.png"), "")
+    compare(PathText.droppedPath("/home/user/plain"), "")
+  }
+
   function test_blank_values_become_empty() {
     compare(PathText.pathText(undefined), "")
     compare(PathText.pathText(null), "")

--- a/tests/source_contract.rs
+++ b/tests/source_contract.rs
@@ -1223,6 +1223,53 @@ fn shared_folder_context_defaults_to_selection_and_can_follow_the_git_project() 
 }
 
 #[test]
+fn a_drag_leaving_a_blade_only_reaches_the_system_when_the_setting_asks_for_it() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let state = text(&root.join("controllers/StateController.qml"));
+    let config = text(&root.join("controllers/ConfigController.qml"));
+    let settings = text(&root.join("modules/files/FilesSettings.qml"));
+    let row = text(&root.join("panes/BrowserRow.qml"));
+    let wheel = text(&root.join("controllers/DropWheelController.qml"));
+    let drop_target = text(&root.join("panes/BrowserDropTarget.qml"));
+    let paths = text(&root.join("lib/PathText.js"));
+    let ipc = text(&root.join("controllers/FileTreeIpc.qml"));
+
+    assert!(state.contains("property string dragOut: \"paste\""));
+    assert!(state.contains("dragOut: service.normalizeDragOut(config.dragOut)"));
+    assert!(state.contains("dragOut: dragOut,"));
+    assert!(
+        config.contains("return [\"paste\", \"system\"].indexOf(mode) >= 0 ? mode : \"paste\"")
+    );
+    let service = text(&root.join("Service.qml"));
+    assert!(service.contains(
+        "function normalizeDragOut(value) { return configController.normalizeDragOut(value) }"
+    ));
+    assert!(service.contains("function setDragOut(value)"));
+    assert!(settings.contains("label: \"Drag out\""));
+    assert!(settings.contains("{ key: \"system\", label: \"System drag\" }"));
+    assert!(ipc.contains("dragOut: service.dragOut,"));
+
+    assert!(row.contains("if (held & Qt.RightButton) return false"));
+    assert!(row.contains("if (keys & (Qt.ShiftModifier | Qt.ControlModifier)) return false"));
+    assert!(row.contains("acceptedButtons: Qt.LeftButton | Qt.RightButton"));
+    assert!(row.contains("if (openWheelNow) controller.dropWheel.openAfterDrag()"));
+    assert!(wheel.contains("function openAfterDrag()"));
+    assert!(row.contains(
+        "row.wheelGesture = (Number(dragHandler.centroid.pressedButtons) & Qt.RightButton) !== 0"
+    ));
+    assert!(
+        row.contains("row.Drag.dragType = row.systemDragActive ? Drag.Automatic : Drag.Internal")
+    );
+    assert!(row.contains(
+        "row.systemDragActive = row.systemDragWanted(dragHandler.centroid.pressedButtons, dragHandler.centroid.modifiers)"
+    ));
+    assert!(wheel.contains("readonly property string pathForm:"));
+    assert!(drop_target.contains("keys: [\"fileblade-entry\", \"text/uri-list\"]"));
+    assert!(drop_target.contains("PathText.droppedPath(drop.urls[i])"));
+    assert!(paths.contains("function droppedPath(value)"));
+}
+
+#[test]
 fn drop_drag_leaves_the_blade_at_the_sheet_edge_not_the_layer_edge() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let surface = text(&root.join("blades/BladeSurface.qml"));
@@ -1248,10 +1295,12 @@ fn drop_drag_leaves_the_blade_at_the_sheet_edge_not_the_layer_edge() {
     assert!(row.contains("else row.Drag.drop()"));
     assert!(row.contains("if (row.dragCanceled) row.Drag.cancel()"));
     assert!(row.contains("Drag.keys: [\"fileblade-entry\"]"));
-    assert!(drop_target.contains("keys: [\"fileblade-entry\"]"));
+    assert!(drop_target.contains("keys: [\"fileblade-entry\", \"text/uri-list\"]"));
     assert!(drop_target.contains("interval: 500"));
     assert!(drop_target.contains("controller.setDirectoryExpanded(rowItem.path, true)"));
-    assert!(drop_target.contains("controller.moveSelectionTo(rowItem.path, drop.proposedAction === Qt.CopyAction, rowItem.draggedPaths.slice())"));
+    assert!(drop_target.contains(
+        "controller.moveSelectionTo(rowItem.path, drop.proposedAction === Qt.CopyAction, paths)"
+    ));
     assert!(row.contains("ownerView.contentY = Math.max"));
     assert!(
         row.contains(

--- a/tests/vm/expectations/17-settings.sh
+++ b/tests/vm/expectations/17-settings.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Settings. Expectations E-17-01 .. E-17-13.
+# Settings. Expectations E-17-01 .. E-17-14.
 source "$(dirname "$0")/lib.sh"
 
 require_guest
@@ -85,5 +85,11 @@ ctl setModeBadge hidden >/dev/null; sleep 1
 expect E-17-11 "and can be hidden" modeBadge hidden
 ctl setModeBadge "${before_badge:-header}" >/dev/null; sleep 1
 expect E-17-11 "and the tree reports its mode" editorMode NORMAL
+
+before_drag=$(field dragOut)
+ctl setDragOut system >/dev/null; sleep 1
+expect E-17-14 "dragging out hands files to the system" dragOut system
+ctl setDragOut "${before_drag:-paste}" >/dev/null; sleep 1
+expect E-17-14 "and paste path comes back" dragOut paste
 
 summary


### PR DESCRIPTION


https://github.com/user-attachments/assets/05e0ce40-4960-4ba3-86a5-a12b078e8e0f

## What this changes

Adds an optional `dragOut` mode so a file drag can leave a blade as a real
Wayland drag and hand the files to the application it is dropped on. The
default, `paste`, keeps today's behavior exactly.

`BrowserRow` already declared a `text/uri-list` payload, but with the default
internal drag type Qt never built a system drag, so the mime data was inert.

A compositor drag owns the pointer and the keyboard for as long as it lasts, so
it cannot share a gesture with the drop wheel, which opens on a key the
compositor no longer delivers. The button therefore chooses the gesture:

| Gesture | Result |
|---|---|
| Left button, `dragOut: system` | the application you drop on receives the files |
| Left button, `dragOut: paste` (default) | unchanged: the drag stays inside FileBlade |
| Right button | stays internal and opens the drop wheel where the drag is released outside a blade |
| Shift or Ctrl + left button | stays internal, absolute and relative path pastes as before |

Row drop targets now accept `text/uri-list` beside the internal drag key,
because a system offer carries mime types instead of the key. That keeps folder
drops working, and it also makes folder rows accept files dragged in from other
applications. `PathText.droppedPath` resolves an offered url whether or not the
compositor percent-encodes it, so a name containing a space arrives intact —
without it, dropping a folder named `folder test` silently did nothing.
`selectionUris` now separates and terminates the list with CRLF per RFC 2483,
which starts to matter once the payload leaves the process.

User documentation: `docs/agent-written/dragging-files.md`, registered in the
documentation catalogue. `README.md` is human-maintained, so I did not touch it;
if you want a line there, something like "hold the right button to drag with the
wheel, or turn on Drag out to hand files to other applications" would cover it.

## Justification

Dragging a file from FileBlade into a browser upload field, a chat window or any
other client that takes files did not work at all: the only drag-out was the
synthetic one, which types paths into the window under the cursor. That is the
right behavior for a terminal and the wrong one for an application that expects
files. This adds the second case without taking the first away, and leaves the
default alone so existing users see no change until they opt in.

## How it was tested

`tests/run` passes up to `tools/bundle verify`, which exits 1 here because the
machine has no `rustup` with the pinned 1.98.0 toolchain. `fileblade-bin: OK`
confirms the checksum and source id are untouched; the change is QML and docs
only, so no bundle rebuild is required. Every Rust, contract, qmllint and QML
suite passes, including a new `tst_path_text` case for dropped urls with spaces
and a new source-contract test for the setting and the gesture.

No VM scenarios were run: the `ovm` harness from `test-omarchy-plugin` is not
available on this machine. `tests/vm/expectations/17-settings.sh` has the
E-17-14 block written but unexecuted, so please treat the live checks below as
the evidence instead.

Live checks on Omarchy 4.0.2, Hyprland, docked blades, running this branch's QML
in the installed plugin:

- `dragOut: system`, left button: one file and three files land in a Firefox
  upload field; three arrive as three
- Right button: the wheel opens where the drag is released outside the blade,
  highlights follow the pointer, scroll and keys work, actions run on the
  dragged files, and cancelling runs nothing
- Shift and Ctrl + left button: absolute and relative path pastes
- Dropping on a folder row inside a blade moves the files, including a folder
  named with a space, which is the bug the url decoding fixes
- Files dragged in from another application land on a folder row
- `dragOut: paste`: wheel, wheel key, scroll, drag scroll, folder drops and path
  pastes all behave as they do on `0.1.3`

Worth flagging: an earlier revision of this branch passed `tests/run` green
while the blade rendered empty at runtime, because a normalizer was not
re-exposed on `Service` and `qmllint` cannot resolve a call across objects. Only
the live check caught it. That is an argument for the live-check rule in
CONTRIBUTING, not against the gate.

## Notes on what was ruled out

I tried to keep both gestures in one drag by starting internal and promoting to
a system drag when the pointer leaves the blade. `Drag.startDrag()` works that
way in an isolated Quickshell panel but not from a blade: it runs and the
compositor never takes over. Direct, deferred with `Qt.callLater`, and with the
focus grab released first all behaved the same, and I could not identify the
cause, so the gesture is decided at press instead.

Probes did establish that a drop wheel could survive inside a system drag if its
trigger moved to `hyprland-global-shortcuts`: a global shortcut fires with the
drag active, a surface created mid-drag receives the offer and the drop with its
urls, pointer motion reaches it (541 events in one drag), and scroll and keys
arrive through compositor binds. That would mean registering temporary binds for
the duration of every drag and leaking them if the process dies mid-gesture, and
it rewrites the wheel's input model, so it is not in this PR. If you want that
direction, the measurements are here and I am happy to do it as a follow-up.

## Review

A coding agent reviewed the diff before this PR and found three things, all
fixed here:

- the row drop target was gated on `dropAllowed`, which derives from the
  internal drag's paths, so an external drag into a fresh session was refused
  and, after any internal drag, was judged against a stale selection. The gate
  now only applies `canDrop` while an internal drag is active.
- releasing a right-button drag while the wheel was already open marked the drag
  consumed, so `endDrag` skipped the branch that resolves the wheel; the wheel
  stayed open with `wheelFromDrag` set and the next drag ran an action the user
  never chose.
- `droppedPath` now rejects query and fragment suffixes, malformed percent
  escapes, control characters and bare `/`, and external drops are validated
  with `DragPlan.canDrop` against the paths actually offered. New
  `tst_path_text` cases cover `..`, `%2e%2e`, `%00`, `file:///` and the rest.

- [ ] `tests/run` passes — everything passes except `tools/bundle verify`, which
      needs `rustup` with the pinned 1.98.0 toolchain and is unavailable on this
      machine; `fileblade-bin: OK` shows the bundle is untouched by this change
- [x] If a source contract test changed, the reason is described above
- [x] I ran a coding agent to review the implementation work, if the original work was generated by another coding agent
- [x] I have checked for any possible security issues
