### PR TITLE
Feat: walk history with the side mouse buttons

### DIFF
--- a/docs/agent-written/keybindings.md
+++ b/docs/agent-written/keybindings.md
@@ -76,6 +76,12 @@ page-up/down, opening and help; `h`/Left returns to the tree. Fold commands
 apply only in a tree. Quick navigation, the picker, search layout and deep
 search are Files-only.
 
+The mouse has one binding of its own, and it is not configurable: the side
+buttons walk the navigation history, matching the `back` and `forward` actions.
+They answer over the files pane, Trash and Drives included, and over the
+properties pane, while that blade has focus and no settings or shortcuts panel
+covers it.
+
 These are pane-navigation bindings, not global Hyprland shortcuts or editor
 input mappings. Text fields, Notes editing, dialogs and module-specific
 mutation commands retain their own keys. The Files shortcut guide displays

--- a/panes/PropertiesPane.qml
+++ b/panes/PropertiesPane.qml
@@ -19,6 +19,15 @@ FocusScope {
   PluginUi.ActionKeyGuard { id: actionKeys; active: root.activeFocus; shared: root.hostWindow ? root.hostWindow.actionKeys : null }
   PluginUi.TreeKeys { id: treeKeys; active: scroller.activeFocus; scope: "properties"; plan: controller.keybindings.plan }
   Keys.onReleased: function(event) { actionKeys.release(event) }
+  TapHandler {
+    acceptedButtons: Qt.BackButton | Qt.ForwardButton
+    gesturePolicy: TapHandler.ReleaseWithinBounds
+    enabled: root.focusEnabled && root.activeFocus
+    onTapped: function(eventPoint, button) {
+      if (button === Qt.BackButton) root.runKeyAction("back")
+      else if (button === Qt.ForwardButton) root.runKeyAction("forward")
+    }
+  }
 
   function targetScreen() {
     return hostWindow ? hostWindow.screen : null

--- a/panes/TreePane.qml
+++ b/panes/TreePane.qml
@@ -21,6 +21,15 @@ FocusScope {
     plan: controller.keybindings.plan
   }
   Keys.onReleased: function(event) { actionKeyGuard.release(event) }
+  TapHandler {
+    acceptedButtons: Qt.BackButton | Qt.ForwardButton
+    gesturePolicy: TapHandler.ReleaseWithinBounds
+    enabled: root.focusEnabled && root.activeFocus
+    onTapped: function(eventPoint, button) {
+      if (button === Qt.BackButton) root.runBrowserAction("back")
+      else if (button === Qt.ForwardButton) root.runBrowserAction("forward")
+    }
+  }
   property var context: null
   property bool focusEnabled: true
   property bool locationEditing: false

--- a/tests/EXPECTATIONS.md
+++ b/tests/EXPECTATIONS.md
@@ -161,6 +161,12 @@ Ids never get reused. When behaviour changes, edit the entry in place.
 43. **E-06-03** If I press `Alt+Home`, I move to my home directory.
 44. **E-06-04** If I click the Up, Back, Forward, or Home buttons, they navigate
     to the same places as their keyboard shortcuts.
+44b. **E-06-09** If my mouse has side buttons, pressing them over the files
+    pane or the properties pane walks the same history as `Alt+Left` and
+    `Alt+Right`, Trash and Drives included. They do nothing while a settings or
+    shortcuts panel covers the blade, or while the blade does not have focus.
+    Pressing one while I am dragging cancels the drag, and pressing one with the
+    actions menu open closes the menu and navigates.
 45. **E-06-05** If I enter a path that does not exist, I see an error and remain
     in the current directory.
 46. **E-06-06** If I enter a valid path whose name ends with spaces, FileBlade

--- a/tests/source_contract.rs
+++ b/tests/source_contract.rs
@@ -1223,6 +1223,20 @@ fn shared_folder_context_defaults_to_selection_and_can_follow_the_git_project() 
 }
 
 #[test]
+fn the_side_mouse_buttons_walk_the_same_history_as_the_keys() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let pane = text(&root.join("panes/TreePane.qml"));
+    let properties = text(&root.join("panes/PropertiesPane.qml"));
+
+    for source in [&pane, &properties] {
+        assert!(source.contains("acceptedButtons: Qt.BackButton | Qt.ForwardButton"));
+        assert!(source.contains("enabled: root.focusEnabled && root.activeFocus"));
+    }
+    assert!(pane.contains("if (button === Qt.BackButton) root.runBrowserAction(\"back\")"));
+    assert!(properties.contains("if (button === Qt.BackButton) root.runKeyAction(\"back\")"));
+}
+
+#[test]
 fn drop_drag_leaves_the_blade_at_the_sheet_edge_not_the_layer_edge() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let surface = text(&root.join("blades/BladeSurface.qml"));


### PR DESCRIPTION
## What this changes

A mouse with back and forward buttons had nothing to press in a blade, even
though the history those buttons mean is the one `Alt+Left` and `Alt+Right`
already walk.

A `TapHandler` accepting only `Qt.BackButton | Qt.ForwardButton` sits on the
files pane and on the properties pane, and routes through `runBrowserAction` /
`runKeyAction` — the same entry points the keybindings use, so an unavailable
direction stays an unavailable direction rather than a second code path.

Putting it on the pane rather than on a row is what makes it answer over Trash
and Drives, which are views inside the files pane, and over empty space below
the last row. It accepts nothing but those two buttons, so clicks, drags, the
context menu and text fields reach the items underneath as before.

It is gated on `focusEnabled && activeFocus`, so it does not fire through the
settings or shortcuts panels, or on a blade that does not have focus.

## Justification

The buttons exist on most mice and mean exactly one thing in a file manager.
Wiring them to the history that already exists is the smallest possible change
that removes a "why does nothing happen" moment.

## How it was tested

`tests/run` passes completely, including `tools/bundle verify` with the pinned
1.98.0 toolchain. No native code changed, so the bundle is untouched.

Live checks on Omarchy 4.0.2, Hyprland, running this branch's QML in the
installed plugin:

- both buttons walk the history in the files pane, in Trash and in Drives
- they work over the properties pane
- they do nothing with the settings panel or the shortcuts panel open, and
  nothing on an unfocused blade
- left click, right click, the context menu and dragging rows are unchanged
- pressing a side button during a drag cancels the drag
- pressing one with the actions menu open closes the menu and navigates

The last two are recorded in E-06-09 rather than left for a user to discover.
Neither is determinable from the source — both depend on Qt 6 pointer-grab
ordering — so they were established by trying them.

No VM scenarios were run; the `ovm` harness is not available on this machine.

## Review

A coding agent reviewed this before the PR and found the gate that was missing.
The first revision had no `enabled` condition, so the buttons navigated the tree
underneath a settings or shortcuts panel — the overlays' scrims default to
`Qt.LeftButton` and do not block Back or Forward — while `Alt+Left` in that
state correctly does nothing. It also caught that the first wording claimed
"anywhere in the files blade", which was false for the properties pane and the
picker bar: the properties pane is covered now, and the wording is narrowed to
what is true. Two smaller ones: the ternary treated any non-Back button as
Forward, now an explicit pair of checks, and the contract test asserted four
things that already passed on the base commit, now trimmed to what this change
actually introduces.

Worth knowing when reading this next to #4: that PR starts a real Wayland drag
on left-button drags, and this handler shares a pane with it. The drag-cancel
behaviour above was checked with both changes live in the same plugin.

- [x] `tests/run` passes
- [x] If a source contract test changed, the reason is described above
- [x] I ran a coding agent to review the implementation work, if the original work was generated by another coding agent
- [x] I have checked for any possible security issues
